### PR TITLE
Dynamically populate metric descriptions and handle header resizing

### DIFF
--- a/web/css/index.css
+++ b/web/css/index.css
@@ -7,7 +7,6 @@
 button {
     width: 100%;
 }
-
 hr {
     margin: 0;
 }

--- a/web/index.html
+++ b/web/index.html
@@ -8,31 +8,25 @@
         Cancer Inequality Data Explorer
     </title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
     <link rel="stylesheet" href="css/index.css">
 </head>
 
 <body>
-
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0-2/js/all.min.js"></script>
-
     <!-- Top navigation bar -->
-    <nav class="navbar" role="navigation" aria-label="main navigation">
-        <div class="navbar-brand">
-            <a class="navbar-item" id="header-logo" href="#">
-                <img src="images/fred-hutch.svg" width="48px" />
-                <h1 class="subtitle">Cancer Inequality Data Explorer</h1>
+    <div class="container">
+        <header class="navbar justify-content-center  border-bottom">
+            <a href="/" class="d-flex me-md-auto text-dark text-decoration-none">
+                <img class="me-2" src="images/fred-hutch.svg" width="40px" />
+                <span class="fs-4">Cancer Inequality Data Explorer</span>
             </a>
-        </div>
-        <div id="navbarMenu" class="navbar-menu">
-            <div class="navbar-end">
-                <a class="navbar-item is-active">Visualization</a>
-                <a class="navbar-item">Data Sources</a>
-                <a class="navbar-item">About</a>
-            </div>
-        </div>
-    </nav>
-
-    <hr>
+            <ul class="nav nav-pills">
+                <li class="nav-item"><a href="#" class="nav-link link-dark" aria-current="page">Visualization</a></li>
+                <li class="nav-item"><a href="#" class="nav-link link-secondary">About</a></li>
+            </ul>
+        </header>
+    </div>
 
     <!-- Main page content -->
     <div class="columns">
@@ -108,14 +102,9 @@
                 </div>
                 <!-- Create an element where the scatterplot and regression results will be rendered. -->
                 <div id="canvas_scatterplot"></div>
-                <div id="scatter_x">
-                    <b>Lung Cancer Incidence</b>: This is the age adjusted number of cases
-                    per 100,000 residents. This data comes from NCI.
-                </div>
-                <div id="scatter_y">
-                    <b>Smoking Prevalence</b>: This is the percent of adults who have
-                    smoked over 50 cigarettes. This data comes from NCI.
-                </div>
+                <!-- Placeholder for the metric descriptions. -->
+                <div id="scatter_y"></div>
+                <div id="scatter_x"></div>
             </section>
         </div>
     </div>

--- a/web/scripts/data-service.js
+++ b/web/scripts/data-service.js
@@ -6,9 +6,12 @@
 let dataPromise;
 
 /**
+ * TODO: Right now this function just returns all the county level data. This
+ * will need to be augmented to handle state data and lat/long data.
+ * @param {string[]} metrics list of metrics to include in the result 
  * @returns a promise that resolves to the county level data.
  */
-function getData() {
+function getData(metrics) {
     if (!dataPromise) {
         dataPromise = new Promise((resolve, reject) => {
             d3.csv("https://raw.githubusercontent.com/agale123/sep-cancer-inequality/main/data/final/county_data.csv", (data) => {
@@ -40,7 +43,20 @@ const METRIC_LABELS = {
  * @param {string} metric 
  * @returns a formatted version of the metric name
  */
-function getFormattedText(metric) {
+function getMetricLabel(metric) {
     return METRIC_LABELS[metric];
 }
 
+const METRIC_DESCRIPTIONS = {
+    "cancer_incidence_rate_per_100000": "The age-adjusted number of cancer cases per 100,000 residents. This data comes from NCI.",
+    "cancer_mortality_rate_per_100000": "The age-adjusted number of cancer deaths per 100,000 residents. This data comes from NCI.",
+    "below_poverty_percent": "The percent of residents who live below the poverty level",
+};
+
+/**
+ * @param {string} metric 
+ * @returns a formatted description of the metric
+ */
+function getMetricDescription(metric) {
+    return METRIC_DESCRIPTIONS[metric];
+}

--- a/web/scripts/scatterplot-visualization.js
+++ b/web/scripts/scatterplot-visualization.js
@@ -25,7 +25,7 @@ async function updateScatterplot(xMetric, yMetric) {
             `translate(${s_margin.left}, ${s_margin.top})`);
 
     // Read the data
-    let data = await getData();
+    let data = await getData([xMetric, yMetric]);
 
     // Remove any missing datapoints    
     data = data.filter(d => d[xMetric] && d[yMetric]);
@@ -46,7 +46,7 @@ async function updateScatterplot(xMetric, yMetric) {
         .attr("text-anchor", "middle")
         .attr("x", s_width / 2)
         .attr("y", s_height + s_margin.top + 15)
-        .text(getFormattedText(xMetric));
+        .text(getMetricLabel(xMetric));
 
     // Add Y axis
     const yMin = d3.min(data, (d) => d[yMetric]);
@@ -63,7 +63,7 @@ async function updateScatterplot(xMetric, yMetric) {
         .attr("transform", "rotate(-90)")
         .attr("x", -(s_margin.top + s_margin.bottom + s_height / 2))
         .attr("y", -s_margin.left + 20)
-        .text(getFormattedText(yMetric))
+        .text(getMetricLabel(yMetric))
 
     // Add dots
     scatterplot.append('g')
@@ -75,14 +75,13 @@ async function updateScatterplot(xMetric, yMetric) {
         .attr("cy", d => y(parseFloat(d[yMetric])))
         .attr("r", 1.5)
         .style("fill", "#69b3a2");
+
+    // Render metric descriptions
+    document.getElementById("scatter_x").innerHTML =
+        `<b>${getMetricLabel(xMetric)}</b>: ${getMetricDescription(xMetric)}`;
+    document.getElementById("scatter_y").innerHTML =
+        `<b>${getMetricLabel(yMetric)}</b>: ${getMetricDescription(yMetric)}`;
 }
 
 // Render with initial data
 updateScatterplot("cancer_incidence_rate_per_100000", "below_poverty_percent");
-
-// Demonstrates that the scatterplot can be updated
-setTimeout(() => {
-    updateScatterplot(
-        "cancer_incidence_rate_per_100000",
-        "cancer_mortality_rate_per_100000");
-}, 5000);


### PR DESCRIPTION
It looks like bulma doesn't support showing the links when the window resizes to be small so I just grabbed a chunk of bootstrap to handle that better. I also updated data-service.js to have a method for getting the metric names so that can be populated dynamically.