### PR TITLE
Add color gradient legend and annotation to the maps

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -68,6 +68,24 @@
                         <!-- Create an SVG element where the first map will be rendered. -->
                         <svg id="canvas_map_one" width="100%" height="300"></svg>
                     </section>
+                    <section class="section px-2 py-1">
+                        <div class="columns p-0">
+                            <!-- Create an SVG element for the first map legend. -->
+                            <div class="column p-0 is-half"></div>
+                            <div class="column p-0"><svg id="canvas_map_one_legend" width="100%" height="15"></svg></div>
+                        </div>
+                    </section>
+                    <section class="section p-0 m-0">
+                        <div class="columns p-0 m-0">
+                            <div class="column p-0 m-0 is-half"></div>
+                            <div class="column p-0 m-0">
+                                <p class="is-size-7 has-text-left" id="canvas_map_one_legend_left"></p>
+                            </div>
+                            <div class="column p-0 m-0">
+                                <p class="is-size-7 has-text-right" id="canvas_map_one_legend_right"></p>
+                            </div>
+                        </div>
+                    </section>
                 </section>
                 <section class="section px-5 py-0">
                     <!-- Dropdown for the second indicator -->
@@ -81,7 +99,24 @@
                         <!-- Create an SVG element where the second map will be rendered. -->
                         <svg id="canvas_map_two" width="100%" height="300"></svg>
                     </section>
-
+                    <section class="section px-2 py-1">
+                        <div class="columns p-0">
+                            <!-- Create an SVG element for the second map legend. -->
+                            <div class="column p-0 is-half"></div>
+                            <div class="column p-0"><svg id="canvas_map_two_legend" width="100%" height="15"></svg></div>
+                        </div>
+                    </section>
+                    <section class="section p-0 m-0">
+                        <div class="columns p-0 m-0">
+                            <div class="column p-0 m-0 is-half"></div>
+                            <div class="column p-0 m-0">
+                                <p class="is-size-7 has-text-left" id="canvas_map_two_legend_left"></p>
+                            </div>
+                            <div class="column p-0 m-0">
+                                <p class="is-size-7 has-text-right" id="canvas_map_two_legend_right"></p>
+                            </div>
+                        </div>
+                    </section>
                 </section>
             </div>
             <!-- Right column -->

--- a/web/scripts/map-visualization.js
+++ b/web/scripts/map-visualization.js
@@ -79,4 +79,29 @@ function renderMap(canvas_name, border_outlines, indicators) {
 
             return fips in indicators ? color(indicators[fips]) : default_color_for_missing_data
         });
+
+    // Draw the legend
+    let gradient_id = canvas_name + "_linear_gradient";
+    let legend = d3.select('#' + canvas_name + "_legend");
+    let defs = legend.append("defs");
+    let linearGradient = defs.append("linearGradient")
+        .attr("id", gradient_id);
+
+    let colorScale = d3.scaleLinear()
+        .range(palette);
+
+    linearGradient.selectAll("stop")
+        .data( colorScale.range() )
+        .enter().append("stop")
+        .attr("offset", (d, i) => i / (colorScale.range().length-1))
+        .attr("stop-color", (d) => d);
+
+    legend.append("rect")
+        .attr("width", "100%")
+        .attr("height", 10)
+        .style("fill", "url(#" + gradient_id + ")");
+
+    // Annotate the legend
+    document.getElementById(canvas_name + "_legend_left").innerHTML = `${Math.floor(indicator_min)}`;
+    document.getElementById(canvas_name + "_legend_right").innerHTML = `${Math.ceil(indicator_max)}`;
 }


### PR DESCRIPTION
This change adds another SVG element next to each map for rendering their respective legends.

The color gradient follow the same palette defined for the map. The annotation shows the min/max value.

Further changes may be necessary to add a legend title (e.g. Cancer incidence per 1000 population) and rounding the min/max numbers to the nearest 100th or more readable scale.