### PR TITLE
Add tooltips when hovering over counties and states

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -26,6 +26,23 @@
     <script src="https://d3js.org/d3-format.v3.min.js"></script>
     <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
     <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
+
+    <style>
+        .tooltip-hidden { 
+            display: none; 
+        }
+        div.tooltip {
+            color: #222; 
+            background: #fff;
+            padding: .5em;
+            text-shadow: #cecece 0 1px 0;
+            font-size: x-small;
+            border-radius: 4px;
+            box-shadow: 0px 0px 2px 0px #c3bcbc;
+            opacity: 0.9;
+            position: absolute;
+        }
+    </style>
 </head>
 
 <body>
@@ -64,7 +81,7 @@
                             <select class="w-100" id="first-select"></select>
                         </div>
                     </div>
-                    <section class="section px-2 py-1">
+                    <section class="section px-2 py-1" id="canvas_map_one_container">
                         <!-- Create an SVG element where the first map will be rendered. -->
                         <svg id="canvas_map_one" width="100%" height="300"></svg>
                     </section>
@@ -95,7 +112,7 @@
                             <select class="w-100" id="second-select"></select>
                         </div>
                     </div>
-                    <section class="section px-2 py-1">
+                    <section class="section px-2 py-1" id="canvas_map_two_container">
                         <!-- Create an SVG element where the second map will be rendered. -->
                         <svg id="canvas_map_two" width="100%" height="300"></svg>
                     </section>

--- a/web/scripts/map-visualization.js
+++ b/web/scripts/map-visualization.js
@@ -59,6 +59,11 @@ function renderMap(canvas_name, border_outlines, indicators) {
     // Clear any past svg elements
     canvas.selectAll("*").remove();
 
+    // Add tooltips
+    let tooltip = d3.select('#' + canvas_name + '_container')
+        .append("div")
+        .attr("class", "tooltip");
+
     // Draw the map
     canvas.append("g")
         .selectAll("path")
@@ -78,7 +83,21 @@ function renderMap(canvas_name, border_outlines, indicators) {
             let fips = Number(county.id);
 
             return fips in indicators ? color(indicators[fips]) : default_color_for_missing_data
-        });
+        })
+        .on("mousemove", (region, i) => {
+            let fips = Number(region.id);
+            let value = fips in indicators ? Math.floor(indicators[fips]) : "N/A";
+
+            // Here we should lookup region details from the Data Service by FIPS. For now,
+            // use the name provided by the county or state border data.
+            let region_name = region.properties.name ? region.properties.name : region.properties.NAME;
+            
+            tooltip
+                .classed("tooltip-hidden", false)
+                .attr("style", "left:" + (d3.event.pageX + 15) + "px;top:" + (d3.event.pageY + 20) + "px")
+                .html(`Name: ${region_name}, Metric: ${value}`)
+        })
+        .on("mouseout",  (d, i) => tooltip.classed("tooltip-hidden", true));
 
     // Draw the legend
     let gradient_id = canvas_name + "_linear_gradient";


### PR DESCRIPTION
This change hooks up events to show/hide a tooltip as the mouse goes over a county or state region.