### PR TITLE
Fix duplicate tooltips

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -64,9 +64,10 @@
                             <select class="w-100" id="first-select"></select>
                         </div>
                     </div>
-                    <section class="section px-2 py-1" id="canvas_map_one_container">
+                    <section class="section px-2 py-1">
                         <!-- Create an SVG element where the first map will be rendered. -->
                         <svg id="canvas_map_one" width="100%" height="300"></svg>
+                        <div class="tooltip tooltip-hidden" id="canvas_map_one_tooltip"></div>
                     </section>
                     <section class="section px-2 py-1">
                         <div class="columns p-0">
@@ -105,9 +106,10 @@
                             <select class="w-100" id="second-select"></select>
                         </div>
                     </div>
-                    <section class="section px-2 py-1" id="canvas_map_two_container">
+                    <section class="section px-2 py-1">
                         <!-- Create an SVG element where the second map will be rendered. -->
                         <svg id="canvas_map_two" width="100%" height="300"></svg>
+                        <div class="tooltip tooltip-hidden" id="canvas_map_two_tooltip"></div>
                     </section>
                     <section class="section px-2 py-1">
                         <div class="columns p-0">

--- a/web/scripts/map-visualization.js
+++ b/web/scripts/map-visualization.js
@@ -85,10 +85,8 @@ function renderMap(canvas_name, indicatorName, border_outlines, indicators) {
     // Clear any past svg elements
     canvas.selectAll("*").remove();
 
-    // Add tooltips
-    let tooltip = d3.select('#' + canvas_name + '_container')
-        .append("div")
-        .attr("class", "tooltip");
+    // Select the tooltip element
+    let tooltip = d3.select('#' + canvas_name + '_tooltip');
 
     // Draw the map
     canvas.append("g")


### PR DESCRIPTION
Problem: A tooltip 'div' element is added every time the map renders. This could leak multiple tooltips on screen.
Fix: Define the tooltip in index.html directly instead of attaching it via script thus only a single element now exits per map.